### PR TITLE
Implement dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the gem to your `Gemfile`:
 
 ```ruby
 group :development, :test do
-  gem 'devpack', '~> 0.2.1'
+  gem 'devpack', '~> 0.3.0'
 end
 ```
 
@@ -40,6 +40,8 @@ require 'devpack'
 ```
 
 Any gems that fail to load (due to `LoadError`) will generate a warning.
+
+All dependencies are recursively verified for compatibily before loading. If no compatible version can be located then the gem will not be loaded.
 
 It is recommended that `.devpack` is added to your `.gitignore`.
 

--- a/lib/devpack.rb
+++ b/lib/devpack.rb
@@ -2,6 +2,7 @@
 
 require 'rubygems'
 require 'pathname'
+require 'set'
 
 require 'devpack/timeable'
 require 'devpack/config'

--- a/lib/devpack/gem_glob.rb
+++ b/lib/devpack/gem_glob.rb
@@ -4,7 +4,9 @@ module Devpack
   # Locates gems by searching in paths listed in GEM_PATH
   class GemGlob
     def find(name)
-      matched_paths(name).max { |a, b| version(a) <=> version(b) }
+      matched_paths(name)
+        .sort { |a, b| version(a) <=> version(b) }
+        .reverse
     end
 
     private

--- a/lib/devpack/gems.rb
+++ b/lib/devpack/gems.rb
@@ -5,8 +5,9 @@ module Devpack
   class Gems
     include Timeable
 
-    def initialize(config)
+    def initialize(config, glob = GemGlob.new)
       @config = config
+      @gem_glob = glob
     end
 
     def load
@@ -21,18 +22,21 @@ module Devpack
     private
 
     def load_devpack
-      @config.requested_gems.map { |name| load_gem(name) }.compact
+      @config.requested_gems.map do |requested|
+        name, _, version = requested.partition(':')
+        load_gem(name, version.empty? ? nil : Gem::Requirement.new("= #{version}"))
+      end.compact
     end
 
-    def load_gem(name)
-      [name, activate(name)]
+    def load_gem(name, requirement)
+      [name, activate(name, requirement)]
     rescue LoadError => e
       warn(Messages.failure(name, load_error_message(e)))
       nil
     end
 
-    def activate(name)
-      spec = GemSpec.new(gem_glob, name)
+    def activate(name, version)
+      spec = GemSpec.new(@gem_glob, name, version)
       update_load_path(spec.require_paths)
       loaded = Kernel.require(name)
       Gem.loaded_specs[name] = spec.gemspec
@@ -49,10 +53,6 @@ module Devpack
       return "(#{error.message})" unless Devpack.debug?
 
       %[(#{error.message})\n#{error.backtrace.join("\n")}]
-    end
-
-    def gem_glob
-      @gem_glob ||= GemGlob.new
     end
 
     def update_load_path(paths)

--- a/lib/devpack/messages.rb
+++ b/lib/devpack/messages.rb
@@ -6,8 +6,7 @@ module Devpack
     class << self
       def failure(name, error_message)
         base = "Failed to load `#{name}`"
-        install = "bundle exec gem install #{name}"
-        "#{base}. Try `#{install}` #{error_message}"
+        "#{base}. #{error_message}"
       end
 
       def initializer_failure(path, error_message)
@@ -24,6 +23,10 @@ module Devpack
 
       def loaded_initializers(path, initializers, time)
         "Loaded #{initializers.compact.size} initializer(s) from '#{path}' in #{time} seconds"
+      end
+
+      def no_compatible_version(dependency)
+        "No compatible version found for `#{dependency.requirement}`"
       end
 
       private

--- a/lib/devpack/version.rb
+++ b/lib/devpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Devpack
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/spec/devpack/gem_glob_spec.rb
+++ b/spec/devpack/gem_glob_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Devpack::GemGlob do
     let(:name) { 'example' }
 
     context 'gem not present in GEM_PATH' do
-      it { is_expected.to be_nil }
+      it { is_expected.to be_empty }
     end
 
     context 'gem present in GEM_PATH' do
@@ -23,11 +23,11 @@ RSpec.describe Devpack::GemGlob do
 
       after { FileUtils.rm_r(gem_path) }
 
-      it { is_expected.to eql gem_path }
+      it { is_expected.to eql [gem_path] }
 
       context 'gem version provided' do
         let(:name) { 'example:0.1.0' }
-        it { is_expected.to eql gem_path }
+        it { is_expected.to eql [gem_path] }
       end
 
       context 'another gem name is a substring of sought gem name' do
@@ -36,7 +36,7 @@ RSpec.describe Devpack::GemGlob do
         let(:other_path) { File.join(base_path, 'gems', 'pry-rails-0.1.0') }
         before { FileUtils.mkdir_p(other_path) }
         after { FileUtils.rm_r(other_path) }
-        it { is_expected.to eql gem_path }
+        it { is_expected.to eql [gem_path] }
       end
 
       context 'older version is string-sorted higher than newer version' do
@@ -45,7 +45,7 @@ RSpec.describe Devpack::GemGlob do
         let(:other_path) { File.join(base_path, 'gems', 'example-0.9.0') }
         before { FileUtils.mkdir_p(other_path) }
         after { FileUtils.rm_r(other_path) }
-        it { is_expected.to eql gem_path }
+        it { is_expected.to eql [gem_path, other_path] }
       end
     end
   end

--- a/spec/devpack/gem_spec_spec.rb
+++ b/spec/devpack/gem_spec_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Devpack::GemSpec do
-  subject(:gem_spec) { described_class.new(glob, name) }
+  subject(:gem_spec) { described_class.new(glob, name, requirement) }
 
+  let(:requirement) { instance_double(Gem::Requirement, satisfied_by?: true) }
   let(:root) { Pathname.new(Dir.tmpdir) }
-  let(:glob) { instance_double(Devpack::GemGlob, find: root.join('gems', 'example-0.1.0')) }
+  let(:glob) { instance_double(Devpack::GemGlob, find: [root.join('gems', 'example-0.1.0')]) }
   let(:name) { 'example' }
   let(:gemspec_content) do
     File.read(File.expand_path(File.join(__dir__, '..', 'fixtures', 'example.gemspec')))
@@ -14,6 +15,7 @@ RSpec.describe Devpack::GemSpec do
     FileUtils.mkdir_p(root.join('gems', 'example-0.1.0'))
     FileUtils.mkdir_p(root.join('specifications', 'example-0.1.0'))
     File.write(root.join('specifications', 'example-0.1.0.gemspec'), gemspec_content)
+    allow(Gem).to receive(:loaded_specs) { {} }
   end
 
   it { is_expected.to be_a described_class }


### PR DESCRIPTION
Ensure that all loaded gems are compatible with the currently-loaded
gemset. Recurse through all dependencies of all required gems and verify
compatibility. Do not load a gem unless all dependencies are compatible.

The previous implementation was comparatively very naïve and loaded
whichever version it found first (which was always the latest available
version). This could cause major issues if e.g. Rack 1.x and 2.x were
both loaded.