### PR TITLE
Fix requiring gems with hyphen corresponding to a `/` in require, and add support for `require: false` type dependency configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,8 @@ Rename `DISABLE_DEVPACK` environment variable to `DEVPACK_DISABLE` for consisten
 ## 0.2.1
 
 Fully activate gem on load: add gem spec to `Gem.loaded_specs` and set instance variables `@loaded` and `@activated` to `true`. This mimics `Gem::Specification#activate` to ensure that anything that depends on these characteristics will function as normal.
+
+## Unreleased
+
+- Add support for gems which are not required automatically 
+- Fix requiring gems where a hyphen in the gem name corresponds to a path slash in the require.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ better_errors
 
 # Optionally specify a version:
 pry:0.13.1
+
+# Or add an asterisk at the start of a line to not require the gem automatically:
+# (equivalent to adding `require: false` to the gem's entry in the Gemfile)
+*brakeman
 ```
 
 Add _Devpack_ to any project's `Gemfile`:

--- a/lib/devpack.rb
+++ b/lib/devpack.rb
@@ -6,6 +6,7 @@ require 'set'
 
 require 'devpack/timeable'
 require 'devpack/config'
+require 'devpack/gem_ref'
 require 'devpack/gems'
 require 'devpack/gem_glob'
 require 'devpack/gem_spec'

--- a/lib/devpack/config.rb
+++ b/lib/devpack/config.rb
@@ -17,6 +17,7 @@ module Devpack
       File.readlines(devpack_path)
           .map(&filter_comments)
           .compact
+          .map { |line| GemRef.parse(line) }
     end
 
     def devpack_path

--- a/lib/devpack/gem_ref.rb
+++ b/lib/devpack/gem_ref.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Devpack
+  class GemRef
+    def self.parse(line)
+      name, _, version = line.partition(':')
+      no_require = name.start_with?('*')
+      name = name.sub('*', '') if no_require
+      new(name: name, version: version.empty? ? nil : Gem::Requirement.new(version), no_require: no_require)
+    end
+
+    def initialize(name:, version: nil, no_require: false)
+      @name = name
+      @version = version
+      @no_require = no_require
+    end
+
+    attr_reader :name, :version
+
+    def require?
+      !@no_require
+    end
+
+    def eql?(other)
+      name == other.name && version == other.version && require? == other.require?
+    end
+
+    def to_s
+      "#{require? ? '*' : ''}#{@name}:#{@version}"
+    end
+  end
+end

--- a/spec/devpack/config_spec.rb
+++ b/spec/devpack/config_spec.rb
@@ -28,7 +28,14 @@ RSpec.describe Devpack::Config do
     after { FileUtils.rm_r(pwd) if File.exist?(pwd) }
 
     it { is_expected.to be_a described_class }
-    its(:requested_gems) { is_expected.to eql %w[gem1 gem2 gem3] }
+    its(:requested_gems) do
+      is_expected.to eql [
+        Devpack::GemRef.new(name: 'gem1', version: nil, no_require: false),
+        Devpack::GemRef.new(name: 'gem2', version: nil, no_require: false),
+        Devpack::GemRef.new(name: 'gem3', version: nil, no_require: false)
+      ]
+    end
+
     its(:devpack_path) { is_expected.to eql Pathname.new(config_path) }
     its(:devpack_initializers_path) do
       is_expected.to eql Pathname.new(File.join(pwd, '.devpack_initializers'))
@@ -75,11 +82,19 @@ RSpec.describe Devpack::Config do
           '  # an indented comment',
           '',
           'gem2', "\t # a tab-indented comment",
-          'gem3 # an in-line comment'
+          'gem3 # an in-line comment',
+          '*gem4 # will not be required'
         ]
       end
 
-      its(:requested_gems) { is_expected.to eql %w[gem1 gem2 gem3] }
+      its(:requested_gems) do
+        is_expected.to eql [
+          Devpack::GemRef.new(name: 'gem1', version: nil, no_require: false),
+          Devpack::GemRef.new(name: 'gem2', version: nil, no_require: false),
+          Devpack::GemRef.new(name: 'gem3', version: nil, no_require: false),
+          Devpack::GemRef.new(name: 'gem4', version: nil, no_require: true)
+        ]
+      end
     end
   end
 end

--- a/spec/devpack/initializers_spec.rb
+++ b/spec/devpack/initializers_spec.rb
@@ -121,8 +121,7 @@ RSpec.describe Devpack::Initializers do
             .with(any_args) do |_level, message|
               next if message.start_with?('Loaded')
 
-              ["/lib/devpack/initializers.rb:28:in `require'",
-               "/lib/devpack/initializers.rb:28:in `load_initializer'",
+              ["/lib/devpack/initializers.rb:28:in `load_initializer'",
                "/lib/devpack/initializers.rb:24:in `block in load_initializers'",
                "/lib/devpack/initializers.rb:24:in `map'",
                "/lib/devpack/initializers.rb:24:in `load_initializers'",


### PR DESCRIPTION
Thanks very much for devpack, great idea.

In gems like `hotwire-livereload` the require is `hotwire/livereload`. Bundler handles this by trying `hotwire-livereload`, catching the LoadError, then trying `hotwire/livereload` , so replicating this here.

Also wanted to support configuration similar to `require: false` in Gemfile, so added support for configuring this in `.devpack` using a `*` prefix to the gem name.

Let me know how this looks and if you would consider adding these contributions!